### PR TITLE
Support explitic nothing in Union{Nothing,T}

### DIFF
--- a/src/StructMapping.jl
+++ b/src/StructMapping.jl
@@ -6,6 +6,7 @@ export convertdict
 _convertdict(::Type{T}, x) where {T} = T(x)
 _convertdict(::Type{Union{T,Nothing}}, x) where {T} = _convertdict(T, x)
 _convertdict(::Type{Union{T,Nothing}}, d::AbstractDict) where {T} = _convertdict(T, d)
+_convertdict(::Type{Union{T,Nothing}}, ::Nothing) where {T} = nothing
 function _convertdict(::Type{T}, v::AbstractVector) where {T<:AbstractVector}
     return T(_convertdict.(eltype(T), v))
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -36,6 +36,7 @@ dict_b = Dict("a" => dict_a, "b" => 4)
 end
 
 dict_b2 = Dict("a" => dict_a)
+dict_b3 = Dict("a" =>  nothing)
 
 @testset "default" begin
     @test convertdict(B, dict_b2) == B(A(1.0, "b"), 0)
@@ -59,6 +60,7 @@ end
 @testset "union" begin
     @test convertdict(D, Dict()) == D()
     @test convertdict(D, dict_b2) == D(A(1.0, "b"))
+    @test convertdict(D, Dict("a" => nothing)) == D()
 end
 
 @with_kw struct E
@@ -68,6 +70,7 @@ end
 @testset "union_vector" begin
     @test convertdict(E, Dict()) == E()
     @test convertdict(E, dict_c).a == [A(1.0, "b"), A(2.0, "b2")]
+    @test convertdict(E, Dict("a" => nothing)) == E()
 end
 
 @with_kw struct F

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -36,7 +36,6 @@ dict_b = Dict("a" => dict_a, "b" => 4)
 end
 
 dict_b2 = Dict("a" => dict_a)
-dict_b3 = Dict("a" =>  nothing)
 
 @testset "default" begin
     @test convertdict(B, dict_b2) == B(A(1.0, "b"), 0)


### PR DESCRIPTION
This fixes #16 

Without this:

```
julia> using Revise,  Parameters, StructMapping

julia> @with_kw struct A
              a::Union{Nothing, String} = nothing
              end
A

julia> convertdict(A, Dict())
A
  a: Nothing nothing


julia> convertdict(A, Dict("a"=>"A"))
A
  a: String "A"


julia> convertdict(A, Dict("a"=>nothing))
ERROR: MethodError: no method matching String(::Nothing)

```

With this:

```
julia> convertdict(A, Dict("a"=>nothing))
A
  a: Nothing nothing

```